### PR TITLE
Core: Handle non-reference terms in metrics evaluators

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.ContentFile;
@@ -105,6 +106,15 @@ public class InclusiveMetricsEvaluator {
       this.upperBounds = file.upperBounds();
 
       return ExpressionVisitors.visitEvaluator(expr, this);
+    }
+
+    @Override
+    public <T> Boolean handleNonReference(Bound<T> term) {
+      // If the term in any expression is not a direct reference, assume that rows may match. This happens when
+      // transforms or other expressions are passed to this evaluator. For example, bucket16(x) = 0 can't be determined
+      // because this visitor operates on data metrics and not partition values. It may be possible to un-transform
+      // expressions for order preserving transforms in the future, but this is not currently supported.
+      return ROWS_MIGHT_MATCH;
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
@@ -98,6 +98,15 @@ public class StrictMetricsEvaluator {
     }
 
     @Override
+    public <T> Boolean handleNonReference(Bound<T> term) {
+      // If the term in any expression is not a direct reference, assume that rows may not match. This happens when
+      // transforms or other expressions are passed to this evaluator. For example, bucket16(x) = 0 can't be determined
+      // because this visitor operates on data metrics and not partition values. It may be possible to un-transform
+      // expressions for order preserving transforms in the future, but this is not currently supported.
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
     public Boolean alwaysTrue() {
       return ROWS_MUST_MATCH; // all rows match
     }


### PR DESCRIPTION
When terms were added to support transforms in Iceberg expressions, existing visitors that only supported references were left unchanged, but the visitor base was updated to throw an exception when a non-reference was found. This updates the reference-based visitor to allow handling non-reference terms using a new method, `handleNonReference`.

The default non-reference handler implementation throws a validation exception like the old behavior. But for some visitors, like the metrics evaluators, a default value can be returned instead of failing. For example, the inclusive metrics evaluator can always return `ROWS_MIGHT_MATCH` because the non-reference term can't be compared against metrics and it is always okay to assume rows might match the evaluator.